### PR TITLE
Add TTL refresh to reduce cache misses

### DIFF
--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -30,6 +30,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractStore
   #       redis: {
   #         db: 2,
   #         expire_after: 120.minutes,
+  #         refresh_ttl: true,
   #         key_prefix: 'myapp:session:',
   #         host: 'host', # Redis host name, default is localhost
   #         port: 12345   # Redis port, default is 6379
@@ -92,7 +93,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractStore
       sid = generate_sid
       session = {}
     end
-
+    refresh(sid)
     [sid, session]
   rescue Errno::ECONNREFUSED => e
     on_redis_down.call(e, env, sid) if on_redis_down
@@ -110,6 +111,14 @@ class RedisSessionStore < ActionDispatch::Session::AbstractStore
     end
   end
 
+  def refresh(sid)
+    refresh = (default_options || env.fetch(ENV_SESSION_OPTIONS_KEY))[:refresh_ttl]
+    expiry  = (default_options || env.fetch(ENV_SESSION_OPTIONS_KEY))[:expire_after]
+    if refresh && expiry
+      redis.expire(prefixed(sid), expiry)
+    end
+  end
+  
   def decode(data)
     serializer.load(data)
   end


### PR DESCRIPTION
if `refresh_ttl` is set to `true` the TTL of the Redis key containing the session will be refreshed. This should stop active sessions from expiring. 